### PR TITLE
Kluge, ALL devices in pushbullet

### DIFF
--- a/plexWatch.pl
+++ b/plexWatch.pl
@@ -2435,8 +2435,9 @@ sub NotifyPushbullet() {
     $po{'title'} .= ': ' . $push_type_titles->{$alert_options->{'push_type'}} if $alert_options->{'push_type'};
     $po{'title'} .= ' ' . ucfirst($alert_options->{'item_type'}) if $alert_options->{'item_type'};
 
+	## This is a kluge, it ignores the device name and thus pushes out to ALL devices registered with pushbullet.  I tried an if/then/else statement on a device name set to "all" but that failed completely.  I don't know much about perl, so that is probably why.
     my $response = $ua->post( "https://$po{'apikey'}\@api.pushbullet.com/api/pushes", [
-				  "device_iden" => $po{'device'},
+				  #"device_iden" => $po{'device'},
 				  "type" => 'note',
 				  "title" => $po{'title'},
 				  "body" => $po{'message'},
@@ -4214,5 +4215,4 @@ This program will Notify and Log 'Now Playing' content from a Plex Media Server
 nothing to see here.
 
 =cut
-
 


### PR DESCRIPTION
This is a total kluge, it removes the device ID attribute from being using in pushbullet which, will send to all devices.  I know know much about perl and was unable to craft an if/then/else statement that would use the device ID if it wasn't set to "all".

I kept getting errors telling me that $responce was undefined, which was extremely frustrating but likely entirely my fault for fussing with a script written in a language I don't know.

The new pushbullet API says if you don't specify a device ID (or anywhere else to send a push) it just sends it out to all devices on a pushbullet account.